### PR TITLE
VaccineStatisticsCompact: fix copy/paste error

### DIFF
--- a/src/components/VaccineStatisticsCompact.js
+++ b/src/components/VaccineStatisticsCompact.js
@@ -771,7 +771,7 @@ const VaccineStatisticsCompact = ({ parsedData, showTweets, dateUpdated }) => {
               />
               <VaccineStatisticsCompactCard
                 title="7-Day Average"
-                description="7-Day Average for 1st Doses"
+                description="7-Day Average for inoculations"
                 mainFigure={Intl.NumberFormat("en").format(
                   Math.round(allDosesStatistics.sevenDaysRate)
                 )}


### PR DESCRIPTION
The card showing the 7-day average of total inoculations was incorrectly labelled as the 7-day average of 1st doses, likely due to a copy/paste error.